### PR TITLE
Corrected argument types in derived classes

### DIFF
--- a/sdk/io/FileReader.ooc
+++ b/sdk/io/FileReader.ooc
@@ -66,7 +66,7 @@ FileReader: class extends Reader {
      * 
      * @return The number of bytes read.
      */
-    read: func (buffer: Char*, offset: Int, count: SizeT) -> SizeT {
+    read: func (buffer: CString, offset: Int, count: Int) -> SizeT {
         file read(buffer + offset, count)
     }
 

--- a/sdk/net/TCPSocket.ooc
+++ b/sdk/net/TCPSocket.ooc
@@ -261,8 +261,9 @@ TCPSocketReader: class extends Reader {
         SocketError new("Sockets do not support rewind") throw()
     }
 
-    seek: func(offset: Long, mode: SeekMode) {
+    seek: func(offset: Long, mode: SeekMode) -> Bool {
         SocketError new("Sockets do not support seek") throw()
+        false
     }
 
     mark: func -> Long { marker }


### PR DESCRIPTION
Seems to work anyway, but this was discovered using the updates in https://github.com/magic-lang/rock/pull/37