### PR TITLE
Correctly detect array access and binary operator side effects

### DIFF
--- a/source/rock/middle/ArrayAccess.ooc
+++ b/source/rock/middle/ArrayAccess.ooc
@@ -32,8 +32,16 @@ ArrayAccess: class extends Expression {
         visitor visitArrayAccess(this)
     }
 
-    // It's just an access, it has no side-effects whatsoever
-    hasSideEffects : func -> Bool { false }
+    // We have side effects if at least one of our indeices has a side effect
+    hasSideEffects : func -> Bool {
+        for (index in indices) {
+            if (index hasSideEffects()) {
+                return true
+            }
+        }
+
+        false
+    }
 
     getGenericOperand: func -> Expression {
         if(getType() isGeneric() && getType() pointerLevel() == 0) {

--- a/source/rock/middle/ArrayAccess.ooc
+++ b/source/rock/middle/ArrayAccess.ooc
@@ -32,8 +32,8 @@ ArrayAccess: class extends Expression {
         visitor visitArrayAccess(this)
     }
 
-    // We have side effects if at least one of our indeices has a side effect
-    hasSideEffects : func -> Bool {
+    // We have side effects if at least one of our indices has a side effect
+    hasSideEffects: func -> Bool {
         for (index in indices) {
             if (index hasSideEffects()) {
                 return true

--- a/source/rock/middle/BinaryOp.ooc
+++ b/source/rock/middle/BinaryOp.ooc
@@ -104,8 +104,10 @@ BinaryOp: class extends Expression {
         visitor visitBinaryOp(this)
     }
 
-    // It's just an access, it has no side-effects whatsoever
-    hasSideEffects : func -> Bool { !isAssign() }
+    // We have side effects if we are assigning to something
+    hasSideEffects : func -> Bool {
+        isAssign()
+    }
 
     getType: func -> Type { inferredType }
 

--- a/test/compiler/operators/binaryop-array-access-side-effects.ooc
+++ b/test/compiler/operators/binaryop-array-access-side-effects.ooc
@@ -1,0 +1,26 @@
+SimpleStack: class <T> {
+    _data: T*
+    _count: SizeT = 0
+    _capacity: SizeT = 8
+    init: func { this _data = gc_malloc(this _capacity * T size) }
+    push: func (element: T) {
+        this _data[this _count] = element
+        this _count += 1
+    }
+
+    pop: func -> T {
+        this _data[this _count -= 1]
+    }
+}
+
+describe("binary operator and array access existance of side effects should be correctly detected", ||
+    stack := SimpleStack<Int> new()
+    stack push(1) . push(2) . push(3)
+
+    a := stack pop()
+    stack pop()
+    b := stack pop()
+
+    expect(3, a)
+    expect(1, b)
+)


### PR DESCRIPTION
Closes #981 (expression never executed if it was in a return statement of a generic function when the result was not stored anywhere)