### PR TITLE
Changed confusing String capitalize()

### DIFF
--- a/sdk/lang/String.ooc
+++ b/sdk/lang/String.ooc
@@ -141,7 +141,7 @@ String: class extends Iterable<Char> {
             case 0 => this
             case 1 => toUpper()
             case =>
-                this[0..1] toUpper() + this[1..-1]
+                this[0] toUpper() + substring(1)
         }
     }
 


### PR DESCRIPTION
Maybe just confusing to me, in that case close and ignore this, but this felt like a better way of doing it.