### PR TITLE
Support Env set() without overwrite on windows

### DIFF
--- a/sdk/os/Env.ooc
+++ b/sdk/os/Env.ooc
@@ -25,8 +25,13 @@ Env: class {
     set: static func (key, value: String, overwrite: Bool) -> Int {
         if(key != null && value != null) {
             version(windows) {
-                // todo: handle overwrite
-                return putenv( "%s=%s" format(key toCString(), value toCString()) toCString() )
+                exists := false
+                if (!overwrite) {
+                    old := This get(key)
+                    exists = (old != null)
+                }
+                if (overwrite || !exists)
+                    return putenv( "%s=%s" format(key toCString(), value toCString()) toCString() )
             }
             version(!windows) {
                 return setenv(key toCString(), value toCString(), overwrite)

--- a/sdk/os/Env.ooc
+++ b/sdk/os/Env.ooc
@@ -25,13 +25,8 @@ Env: class {
     set: static func (key, value: String, overwrite: Bool) -> Int {
         if(key != null && value != null) {
             version(windows) {
-                exists := false
-                if (!overwrite) {
-                    old := This get(key)
-                    exists = (old != null)
-                }
-                if (overwrite || !exists)
-                    return putenv( "%s=%s" format(key toCString(), value toCString()) toCString() )
+                if (overwrite || This get(key) == null)
+                    return putenv("%s=%s" format(key toCString(), value toCString()) toCString())
             }
             version(!windows) {
                 return setenv(key toCString(), value toCString(), overwrite)


### PR DESCRIPTION
Fixes an old todo. Adapted from changes here: https://github.com/magic-lang/ooc-kean/pull/1590/files