### PR TITLE
Class load functions are now only ever evaluated once.

### DIFF
--- a/source/rock/backend/cnaughty/ClassDeclWriter.ooc
+++ b/source/rock/backend/cnaughty/ClassDeclWriter.ooc
@@ -187,6 +187,10 @@ ClassDeclWriter: abstract class extends Skeleton {
             current app(' '). openBlock(). nl()
 
             if(decl getName() == ClassDecl LOAD_FUNC_NAME) {
+
+                // Make sure the load function is only evaluated once.
+                current app("static _Bool __done__ = false;") . nl() . app("if(!__done__)") . openBlock() . nl() . app("__done__ = true;") . nl()
+
                 superRef := cDecl getSuperRef()
                 finalScore: Int
                 superLoad := superRef getFunction(ClassDecl LOAD_FUNC_NAME, null, null, finalScore&)
@@ -198,6 +202,8 @@ ClassDeclWriter: abstract class extends Skeleton {
                     if(vDecl getExpr() == null) continue
                     current nl(). app(cDecl getNonMeta() underName()). app("_class()->"). app(vDecl getName()). app(" = "). app(vDecl getExpr()). app(';')
                 }
+
+                current closeBlock()
             }
 
             for(stat in decl body) {

--- a/source/rock/backend/cnaughty/ModuleWriter.ooc
+++ b/source/rock/backend/cnaughty/ModuleWriter.ooc
@@ -165,13 +165,13 @@ ModuleWriter: abstract class extends Skeleton {
 
         // Finally, the rest of the variable declarations and statements
         for (stmt in module body) {
-            match stmt {
-                case vd: VariableDecl =>
-                    if (!vd getType() instanceOf?(AnonymousStructType) && !vd isGenerated && !vd isExtern() && !vd getExpr() == null) {
-                        writeVDecl(vd)
-                    }
-                case =>
-                    writeLine(stmt)
+            if (stmt instanceOf?(VariableDecl) && !stmt as VariableDecl getType() instanceOf?(AnonymousStructType)) {
+                vd := stmt as VariableDecl
+                if (!vd isGenerated && !vd isExtern() && !vd getExpr() == null) {
+                    writeVDecl(vd)
+                }
+            } else {
+                writeLine(stmt)
             }
         }
         current untab(). nl(). app("}")

--- a/source/rock/backend/cnaughty/ModuleWriter.ooc
+++ b/source/rock/backend/cnaughty/ModuleWriter.ooc
@@ -135,6 +135,21 @@ ModuleWriter: abstract class extends Skeleton {
             current nl(). app(imp getModule() getLoadFuncName()). app("();")
         }
 
+        writeVDecl := func (decl: VariableDecl) {
+            current nl() . app(decl getFullName()) . app(" = ") . app(decl getExpr()) . app(';')
+        }
+
+        // We write generated variable declarations first, as they may be required by class static initializers.
+        for (stmt in module body) {
+            match stmt {
+                case vd: VariableDecl =>
+                    if (vd isGenerated) {
+                        writeVDecl(vd)
+                    }
+            }
+        }
+
+        // Then, class load calls
         for (type in module types) {
             if(type instanceOf?(ClassDecl)) {
                 cDecl := type as ClassDecl
@@ -148,13 +163,15 @@ ModuleWriter: abstract class extends Skeleton {
             }
         }
 
-        for(stmt in module body) {
-            if(stmt instanceOf?(VariableDecl) && !stmt as VariableDecl getType() instanceOf?(AnonymousStructType)) {
-                vd := stmt as VariableDecl
-                if(vd isExtern() || vd getExpr() == null) continue
-                current nl(). app(vd getFullName()). app(" = "). app(vd getExpr()). app(';')
-            } else {
-                writeLine(stmt)
+        // Finally, the rest of the variable declarations and statements
+        for (stmt in module body) {
+            match stmt {
+                case vd: VariableDecl =>
+                    if (!vd getType() instanceOf?(AnonymousStructType) && !vd isGenerated && !vd isExtern() && !vd getExpr() == null) {
+                        writeVDecl(vd)
+                    }
+                case =>
+                    writeLine(stmt)
             }
         }
         current untab(). nl(). app("}")

--- a/test/compiler/classes/load-function-once.ooc
+++ b/test/compiler/classes/load-function-once.ooc
@@ -1,0 +1,15 @@
+
+sideEffects: func -> Int {
+    count := static 0
+    count += 1
+}
+
+Base: class {
+    count := static sideEffects()
+}
+
+Derived: class extends Base {}
+
+describe("class load functions should only ever be evaluated once", ||
+    expect(1, Base count)
+)


### PR DESCRIPTION
Closes #992.  

In addition, generated variable declarations are now initialized before class load functions are called.